### PR TITLE
SQUASH: adds backticks to test string for alignment

### DIFF
--- a/qiime2/sdk/tests/test_pipeline.py
+++ b/qiime2/sdk/tests/test_pipeline.py
@@ -171,7 +171,7 @@ class TestPipeline(unittest.TestCase):
 
     def test_failing_from_return_view(self):
         for call in self.iter_callables('failing_pipeline'):
-            with self.assertRaisesRegex(TypeError, 'Result objects'):
+            with self.assertRaisesRegex(TypeError, '`Result` objects'):
                 call(self.int_sequence, break_from='return-view')
 
     def test_failing_from_method(self):


### PR DESCRIPTION
Not sure what your plans were for this little fix, @thermokarst , but it looks like Travis is only breaking on the backticks you added to the user-facing error message. 